### PR TITLE
Adição do nó de AVS

### DIFF
--- a/BraspagApiDotNetSdk/BraspagApiDotNetSdk.csproj
+++ b/BraspagApiDotNetSdk/BraspagApiDotNetSdk.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Contracts\Antifraud\ShippingData.cs" />
     <Compile Include="Contracts\Antifraud\TravelData.cs" />
     <Compile Include="Contracts\Antifraud\TravelLegData.cs" />
+    <Compile Include="Contracts\Avs.cs" />
     <Compile Include="Contracts\Customer.cs" />
     <Compile Include="Contracts\Enum\AntifraudSequenceCriteriaEnum.cs" />
     <Compile Include="Contracts\Enum\AntifraudSequenceEnum.cs" />

--- a/BraspagApiDotNetSdk/BraspagApiDotNetSdk.nuspec
+++ b/BraspagApiDotNetSdk/BraspagApiDotNetSdk.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>Braspag.ApiDotNetSdk</id>
-		<version>2.9.5</version>
+		<version>2.9.6</version>
 		<authors>Braspag</authors>
 		<owners>Braspag</owners>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/BraspagApiDotNetSdk/Contracts/Avs.cs
+++ b/BraspagApiDotNetSdk/Contracts/Avs.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BraspagApiDotNetSdk.Contracts
+{
+    public class Avs
+    {
+        public string Cpf { get; set; }
+        public string ZipCode { get; set; }
+        public string Street { get; set; }
+        public string Number { get; set; }
+        public string Complement { get; set; }
+        public string District { get; set; }
+        public int Status { get; set; }
+        public string ReturnCode { get; set; }
+    }
+}

--- a/BraspagApiDotNetSdk/Contracts/Card.cs
+++ b/BraspagApiDotNetSdk/Contracts/Card.cs
@@ -20,5 +20,7 @@ namespace BraspagApiDotNetSdk.Contracts
 		public string Alias { get; set; }
 
 		public BrandEnum Brand { get; set; }
-	}
+
+        public Avs Avs { get; set; }
+    }
 }

--- a/BraspagApiDotNetSdk/Properties/AssemblyInfo.cs
+++ b/BraspagApiDotNetSdk/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("df86213d-34ff-4c5b-b406-64054adc9985")]
-[assembly: AssemblyVersion("2.9.5.0")]
-[assembly: AssemblyFileVersion("2.9.5.0")]
+[assembly: AssemblyVersion("2.9.6.0")]
+[assembly: AssemblyFileVersion("2.9.6.0")]


### PR DESCRIPTION
Adição do nó de AVS, para permitir transacionar com análise de endereço/CPF pelo pagador REST.