### PR TITLE
Tornar o Status do AVS nullable

### DIFF
--- a/BraspagApiDotNetSdk/BraspagApiDotNetSdk.nuspec
+++ b/BraspagApiDotNetSdk/BraspagApiDotNetSdk.nuspec
@@ -2,13 +2,13 @@
 <package>
 	<metadata>
 		<id>Braspag.ApiDotNetSdk</id>
-		<version>2.9.7</version>
+		<version>2.9.8</version>
 		<authors>Braspag</authors>
 		<owners>Braspag</owners>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>Implementação do Sdk Api Pagador</description>
 		<releaseNotes>
-      - Including ZeroAuth Method
+      - Status do AVS nullable
     </releaseNotes>
 		<copyright>Braspag Copyright 2015</copyright>
 	</metadata>

--- a/BraspagApiDotNetSdk/Contracts/Avs.cs
+++ b/BraspagApiDotNetSdk/Contracts/Avs.cs
@@ -13,7 +13,7 @@ namespace BraspagApiDotNetSdk.Contracts
         public string Number { get; set; }
         public string Complement { get; set; }
         public string District { get; set; }
-        public int Status { get; set; }
+        public int? Status { get; set; }
         public string ReturnCode { get; set; }
     }
 }

--- a/BraspagApiDotNetSdk/Properties/AssemblyInfo.cs
+++ b/BraspagApiDotNetSdk/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("df86213d-34ff-4c5b-b406-64054adc9985")]
-[assembly: AssemblyVersion("2.9.7.0")]
-[assembly: AssemblyFileVersion("2.9.7.0")]
+[assembly: AssemblyVersion("2.9.8.0")]
+[assembly: AssemblyFileVersion("2.9.8.0")]


### PR DESCRIPTION
Alteração no campo "Status" do nó "Avs" necessária para durante a "serialização" o Status não subir com valor default "0".